### PR TITLE
Fix the gap sometimes caused by wide images

### DIFF
--- a/theme/blank.html.erb
+++ b/theme/blank.html.erb
@@ -71,7 +71,7 @@
 
 <h1><%= image_tag 'i/logo.png', :class => "logo" %><%= site.title %></h1>
 
-
+<div id="articles">
 <%
    items = site.items.latest.limit(24)
    ItemCursor.new( items ).each do |item, new_date, new_feed|
@@ -149,6 +149,7 @@
 
 <% end %><!-- each item -->
 
+</div>
 
 </body>
 </html>

--- a/theme/css/blank.css
+++ b/theme/css/blank.css
@@ -9,6 +9,9 @@ a { text-decoration: none; }
 .small {
   font-size: 12px; }
 
+#articles {
+  margin-right: 210px; }
+
 #navwrap {
   float: right;
   background-color: white;

--- a/theme/css/blank.scss
+++ b/theme/css/blank.scss
@@ -12,7 +12,7 @@ $small-font-size: 12px;
 body {
   font-family: 'Helvetica Neue', Arial, sans-serif;
   line-height: 1.6666;
-  color: #222; }
+  color: #222;
 }
 
 
@@ -29,7 +29,9 @@ a {
   font-size: $small-font-size;
 }
 
-
+#articles {
+  margin-right: 210px;
+}
 
 #navwrap {
   float: right;


### PR DESCRIPTION
Add an 'articles' div around the full set of articles displayed in
the main part of the page. Constrain the width of the whole lot
rather than trying to flow around the right-hand panel.

Fixes https://github.com/gravitystorm/blogs.osm.org/issues/19

Looks like this:
![screen shot 2017-02-24 at 17 53 28](https://cloud.githubusercontent.com/assets/227525/23314499/3793862a-faba-11e6-8db0-025686e9d661.png)

