### PR TITLE
"We prefer feeds which include the full text"

### DIFF
--- a/FEEDS.md
+++ b/FEEDS.md
@@ -9,6 +9,7 @@ The configuration file that contains the list of feeds currently used is [planet
 The aggregator should contain articles from blogs that are relevant to the OpenStreetMap community.
 
 * For personal blogs, we prefer feeds for OpenStreetMap categories or tags, rather than full blogs which can contain a wide variety of subjects
+* We prefer feeds which include the full text of the blog posts rather them just the top section/summary.
 * We will include Organisation feeds only if a majority of their posts are of interest to mappers, rather than posts about products that contain OpenStreetMap functionality.
 * We will consider removing feeds if less than 30% of their recent entries are related to OpenStreetMap.
 * We will remove feeds if a domain is no longer relevant to the OpenStreetMap community


### PR DESCRIPTION
State that we *prefer* feeds to include the full text of the blog post (not required but preferred).

This means a feed like Mapilliary's rss https://blog.mapillary.com/rss.xml is not disallowed on that basis, but if there was a marginal choice whether to include/exclude a feed, it might tip the balance against.