### PR TITLE
Fix link to sosm.ch feed

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -195,8 +195,8 @@ title = OpenStreetMap Blogs
   twitter = osmandapp
 [sosm_ch]
   title = Swiss OSM Association
-  link = http://sosm.ch/
-  feed = http://osmand.net/rss.xml
+  link = https://sosm.ch/
+  feed = https://sosm.ch/feed/atom/
   twitter = swissosm
 [toby_murray]
   title = Toby Murray


### PR DESCRIPTION
It was duplicating the osmand feed, presumably through a copy+paste error.