### PR TITLE
Add new id editor blog

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -263,4 +263,7 @@ title = OpenStreetMap Blogs
   title = osm tree-athlon
   link = https://osmtreeathlon.blogspot.com
   feed = http://osmtreeathlon.blogspot.com/feeds/posts/default?alt=rss
-
+[id_editor]
+  title = iD editor
+  link = https://ideditor.blog/
+  feed = https://ideditor.blog/feed.xml


### PR DESCRIPTION
There's a new id editor blog https://ideditor.blog
Only one post there so far, so maybe we should hold off until they've established it more, but on the other hand I guess we can expect that team to follow through on it.