### PR TITLE
Add noindex meta tag

### DIFF
--- a/theme/blank.html.erb
+++ b/theme/blank.html.erb
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset='utf-8'>
+  <meta name="robots" content="noindex, follow">
   <meta name='generator' content='<%= Pluto.generator %>'>
 
   <title><%= site.title %></title>


### PR DESCRIPTION
Google (and other search engines) should follow all links on this page, but only index the actual blogposts and not the list of blogposts. This meta tag tells google to do just that (https://developers.google.com/search/docs/advanced/crawling/block-indexing?hl=en).

Part of https://github.com/openstreetmap/openstreetmap-website/issues/2851; the part about canonical in this issues is obsolete with this change.