### PR TITLE
Add OpenCage OSM-interviews feed

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -275,3 +275,8 @@ title = OpenStreetMap Blogs
   title = Nominatim
   link = https://nominatim.org/blog/
   feed = https://nominatim.org/feed.xml
+[opencage]
+  title = OpenCage
+  link = https://blog.opencagedata.com/tagged/osminterview
+  feed = https://blog.opencagedata.com/feed/by_tag/osminterview.xml
+  twitter = opencage


### PR DESCRIPTION
Following FEEDS.md https://blog.opencagedata.com/tagged/osminterview contains OpenStreetMap related content. Feed is in atom format.