### PR TITLE
Revert "New URL for Andrew Harvey blog"

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -161,8 +161,8 @@ title = OpenStreetMap Blogs
   feed = https://blog.jochentopf.com/feed.xml
 [andrew_harvey]
   title = Andrew Harvey
-  link = https://tianjara.net/blog/tags/osm/
-  feed = https://tianjara.net/blog/tags/osm/osm.rss
+  link = http://andrewharvey4.wordpress.com/tag/osm/
+  feed = http://andrewharvey4.wordpress.com/tag/osm/feed/
   twitter = alantgeo
 [jerry_clough]
   title = Jerry Clough


### PR DESCRIPTION
Reverts gravitystorm/blogs.osm.org#71

The new feed is broken and causing issues. Also has no new content.