### PR TITLE
Update planet.ini to point to new dankarran.com blog URLs

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -29,11 +29,11 @@ title = OpenStreetMap Blogs
 #  link = http://brainoff.com/weblog/
 #  feed = http://brainoff.com/weblog/feed
 #  twitter = mikel
-#[dan_karran]
-#  title = Dan Karran
-#  link = http://www.dankarran.com/blog/geographic/
-#  feed = http://www.dankarran.com/blog/geographic/feed
-#  twitter = dankarran
+[dan_karran]
+  title = Dan Karran
+  link = https://www.dankarran.com/categories/geographic/
+  feed = https://www.dankarran.com/categories/geographic/index.xml
+  twitter = dankarran
 [andy_allan]
   title = Andy Allan
   link = http://blog.gravitystorm.co.uk/


### PR DESCRIPTION
I've recently reinstated my blog, though the URLs have changed slightly.

It doesn't contain all the old content (yet), but is that likely to cause an issue if I later backfill content? Is the aggregator smart enough to ignore content dated earlier than the most recent post it's pulled in?