### PR TITLE
Add arm64-darwin-22 + aarch64-linux-gnu to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
     rubyzip (2.3.2)
     sassc (2.4.0)
       ffi (~> 1.9)
+    sqlite3 (1.6.8-aarch64-linux)
+    sqlite3 (1.6.8-arm64-darwin)
     sqlite3 (1.6.8-x86_64-linux)
     textutils (1.4.0)
       activesupport
@@ -97,6 +99,8 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  aarch64-linux-gnu
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Add support for `Mac Silicon` and `Linux arm / aarch64`

This allows installing the Gems on Apple Mac and Linux ARM (aka Docker on Apple)