### PR TITLE
Correct uri for f.zz.de from http to https

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -221,8 +221,8 @@ title = OpenStreetMap Blogs
   feed = http://radio.osmz.ru/rss/
 [florian_lohoff]
   title = Florian Lohoff
-  link = http://f.zz.de/tags/osm/
-  feed = http://f.zz.de/tags/osm/index.atom
+  link = https://f.zz.de/tags/osm/
+  feed = https://f.zz.de/tags/osm/index.atom
 [openrailwaymap_en]
   title = OpenRailwayMap (English)
   feed = http://blog.openrailwaymap.org/en.rss


### PR DESCRIPTION
f.zz.de switched to https only a long time ago and excepted .atom and .rss in http -> https redirect. 

This accidentally failed a couple weeks back after preparation to move machines. So switch to using https.