### PR TITLE
Add FOSSGIS / OSM Germany Feed

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -291,3 +291,7 @@ title = OpenStreetMap Blogs
   link = https://blog.opencagedata.com/tagged/osminterview
   feed = https://blog.opencagedata.com/feed/by_tag/osminterview.xml
   twitter = opencage
+[fossgis]
+  title = FOSSGIS e.V. / OSM Germany
+  link = https://fossgis.de/news/kategorien/openstreetmap/
+  feed = https://fossgis.de/news/kategorien/openstreetmap/index.xml


### PR DESCRIPTION
Add link to blog of FOSSGIS e.V, the OSMF Local Chapter for Germany. Links are to the category feed for OSM stuff only.

Blog is in German language.